### PR TITLE
Add up-for-grabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ https://github.com/EddieHubCommunity/LinkFree
 
 Built on: Ruby, nodejs, javascript, typescript, css, html, docker, mongodb, reactjs, nextjs, tailwind
 
+https://github.com/up-for-grabs/up-for-grabs.net
+
+---
+
 ## Another Project
 
 > Make sure to include a small but informative description on what this project is about.

--- a/README.md
+++ b/README.md
@@ -282,6 +282,11 @@ https://github.com/EddieHubCommunity/LinkFree
 
 ---
 
+## up-for-grabs/up-for-grabs.net
+> This repository contains the content for the Up-For-Grabs website, a list of projects with curated tasks for new contributors.
+
+Built on: Ruby, nodejs, javascript, typescript, css, html, docker, mongodb, reactjs, nextjs, tailwind
+
 ## Another Project
 
 > Make sure to include a small but informative description on what this project is about.


### PR DESCRIPTION
This repository contains the content for the Up-For-Grabs website, a list of projects with curated tasks for new contributors.
https://github.com/up-for-grabs/up-for-grabs.net